### PR TITLE
Fix jcbcurl parsing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ subprojects {
     apply plugin: 'maven'
     apply plugin: 'com.jfrog.bintray'
 
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+
     bintray {
         user = System.getenv('BINTRAY_USER')
         key = System.getenv('BINTRAY_KEY')

--- a/eventuate-local-java-embedded-cdc/src/main/java/io/eventuate/local/cdc/debezium/JdbcUrlParser.java
+++ b/eventuate-local-java-embedded-cdc/src/main/java/io/eventuate/local/cdc/debezium/JdbcUrlParser.java
@@ -5,7 +5,7 @@ import java.util.regex.Pattern;
 
 public class JdbcUrlParser {
   public static JdbcUrl parse(String dataSourceURL) {
-    Pattern p = Pattern.compile("jdbc:mysql://([^:/]+)(:[0-9]+)?/(.+$)");
+    Pattern p = Pattern.compile("jdbc:mysql://([^:/]+)(:[0-9]+)?/([^?]+)(\\?.*)?$");
     Matcher m = p.matcher(dataSourceURL);
 
     if (!m.matches())

--- a/eventuate-local-java-embedded-cdc/src/test/java/io/eventuate/local/cdc/debezium/JdbcUrlParserTest.java
+++ b/eventuate-local-java-embedded-cdc/src/test/java/io/eventuate/local/cdc/debezium/JdbcUrlParserTest.java
@@ -24,4 +24,12 @@ public class JdbcUrlParserTest {
 
   }
 
+  @Test
+  public void shouldParseUrlWithParameters() {
+    JdbcUrl jdbcUrl = JdbcUrlParser.parse("jdbc:mysql://192.168.99.101:3306/eventuate?useUnicode=true");
+    assertEquals("192.168.99.101", jdbcUrl.getHost());
+    assertEquals(3306, jdbcUrl.getPort());
+    assertEquals("eventuate", jdbcUrl.getDatabase());
+  }
+
 }


### PR DESCRIPTION
This PR fixes parsing of database name from JDBC URL when there are additional parameters.

Also, it adds source and target version to gradle, which fixed the problem of my intellij idea trying to use `1.7` as source language version.