### PR TITLE
Allow configuration of offset nad history storage to file

### DIFF
--- a/eventuate-local-java-embedded-cdc/src/main/java/io/eventuate/local/cdc/debezium/EventTableChangesToAggregateTopicRelay.java
+++ b/eventuate-local-java-embedded-cdc/src/main/java/io/eventuate/local/cdc/debezium/EventTableChangesToAggregateTopicRelay.java
@@ -14,12 +14,15 @@ import org.apache.curator.framework.recipes.leader.LeaderSelectorListener;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.storage.FileOffsetBackingStore;
 import org.apache.kafka.connect.storage.KafkaOffsetBackingStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
+import java.nio.file.Paths;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -42,6 +45,9 @@ public class EventTableChangesToAggregateTopicRelay {
   private final String dbUser;
   private final String dbPassword;
   private final LeaderSelector leaderSelector;
+
+  @Value("${debezium.data.path:#{null}}")
+  private String dataPath;
 
   private AtomicReference<RelayStatus> status = new AtomicReference<>(RelayStatus.IDLE);
 
@@ -157,15 +163,29 @@ public class EventTableChangesToAggregateTopicRelay {
     producer = new EventuateKafkaProducer(kafkaBootstrapServers);
 
     String connectorName = "my-sql-connector";
-    Configuration config = Configuration.create()
-                                    /* begin engine properties */
+    Configuration.Builder builder = Configuration.create();
+    if (dataPath != null) {
+      builder = builder.with("offset.storage",
+          FileOffsetBackingStore.class.getName())
+          .with("offset.storage.file.filename",
+              Paths.get(dataPath, "offset.dat").toAbsolutePath())
+          .with("database.history.file.filename",
+              Paths.get(dataPath, "dbhistory.dat").toAbsolutePath())
+          .with("database.history",
+              io.debezium.relational.history.FileDatabaseHistory.class.getName());
+    } else {
+      builder = builder.with("database.history",
+          io.debezium.relational.history.KafkaDatabaseHistory.class.getName())
+          .with("database.history.kafka.topic",
+              "eventuate.local.cdc." + connectorName + ".history.kafka.topic")
+          .with("offset.storage",
+              KafkaOffsetBackingStore.class.getName())
+          .with("offset.storage.topic", "eventuate.local.cdc." + connectorName + ".offset.storage");
+    }
+    Configuration config = builder
             .with("connector.class",
                     "io.debezium.connector.mysql.MySqlConnector")
-
-            .with("offset.storage", KafkaOffsetBackingStore.class.getName())
             .with("bootstrap.servers", kafkaBootstrapServers)
-            .with("offset.storage.topic", "eventuate.local.cdc." + connectorName + ".offset.storage")
-
             .with("poll.interval.ms", 50)
             .with("offset.flush.interval.ms", 6000)
                                     /* begin connector properties */
@@ -178,10 +198,7 @@ public class EventTableChangesToAggregateTopicRelay {
             .with("database.server.name", "my-app-connector")
             // Unnecessary.with("database.whitelist", jdbcUrl.getDatabase())
             .with("table.whitelist", jdbcUrl.getDatabase() + ".events")
-            .with("database.history",
-                    io.debezium.relational.history.KafkaDatabaseHistory.class.getName())
-            .with("database.history.kafka.topic",
-                    "eventuate.local.cdc." + connectorName + ".history.kafka.topic")
+
             .with("database.history.kafka.bootstrap.servers",
                     kafkaBootstrapServers)
             .build();


### PR DESCRIPTION
Due to our current Kafka configuration, Debezium's `history` and `offset` topics expires and gets cleared and if you restart CDC after that, changes in `events` table gets ignored by Debezium.

Debezium supports storing of the history/offsets in a file. This PR adds ability to use that functionality.